### PR TITLE
Fix to change_column_null

### DIFF
--- a/lib/active_record/postgresql_extensions/adapter_extensions.rb
+++ b/lib/active_record/postgresql_extensions/adapter_extensions.rb
@@ -684,7 +684,7 @@ module ActiveRecord
           end
           execute("ALTER TABLE #{quote_table_name(table_name)} ALTER #{quote_column_name(column_name)} #{null ? 'DROP' : 'SET'} NOT NULL")
         else
-          change_column_null_without(table_name, column_name, null, default = nil)
+          change_column_null_without_expression(table_name, column_name, null, default = nil)
         end
       end
       alias_method_chain :change_column_null, :expression


### PR DESCRIPTION
The alias_method_chain for change_column_null generates
change_column_null_without_expression, but change_column_null was
sending change_column_null_without, instead (missing "_expression").
